### PR TITLE
Update to Visual Studio 2019 Toolset (v142)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,6 @@
+image: Visual Studio 2019
+configuration:
+  - Release
+  - Debug
+build:
+  project: OPUNetGameServer.sln

--- a/OPUNetGameServer.vcxproj
+++ b/OPUNetGameServer.vcxproj
@@ -18,13 +18,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/OPUNetGameServer.vcxproj
+++ b/OPUNetGameServer.vcxproj
@@ -58,7 +58,6 @@
       <Optimization>Disabled</Optimization>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
-      <MinimalRebuild>true</MinimalRebuild>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\Debug\</AssemblerListingLocation>

--- a/OPUNetGameServer.vcxproj
+++ b/OPUNetGameServer.vcxproj
@@ -58,7 +58,6 @@
       <Optimization>Disabled</Optimization>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\Debug\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\Debug\OPUNetGameServer.pch</PrecompiledHeaderOutputFile>


### PR DESCRIPTION
The following Warnings were generated on toolset update:

Warning	C6387	'gameInfo' could be '0':  this does not adhere to the specification for the function 'memcpy'. 	OPUNetGameServer	\NETFIXSERVER\GAMESERVER.CPP	490	

<img width="611" alt="C6387" src="https://user-images.githubusercontent.com/15183337/74800342-27d98300-52a1-11ea-9ee8-911e49ca46b2.png">

Warning	C4244	'=': conversion from 'time_t' to 'unsigned int', possible loss of data	OPUNetGameServer	\NetFixServer\GameServer.cpp	378	

Not sure if we want to fix now, file for later, or just leave well enough alone.