### PR TITLE
Fix memcpy usage

### DIFF
--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -487,7 +487,9 @@ int GameServer::GetNewGameInfo()
 			return -1;			// Abort (Failed, could not allocate space)
 
 		// Copy the old info to the new array
-		memcpy(newGameInfo, gameInfo, numGames * sizeof(GameInfo));
+		if (gameInfo != nullptr) {
+			memcpy(newGameInfo, gameInfo, numGames * sizeof(GameInfo));
+		}
 
 		// Update the array info
 		delete[] gameInfo;


### PR DESCRIPTION
This will prevent incorrect usage of memcopy. I think it doesn't affect the logic of the program negatively, but wasn't sure enough to merge without having @DanRStevens look at it.

Warning C6387 'gameInfo' could be '0': this does not adhere to the specification for the function 'memcpy'. OPUNetGameServer \NETFIXSERVER\GAMESERVER.CPP 490