### PR TITLE
Fix Overflow warning with TimeT

### DIFF
--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -363,7 +363,7 @@ void GameServer::DoTimedUpdates()
 {
 	int i;
 	time_t currentTime;
-	unsigned int timeDiff;
+	time_t timeDiff;
 
 	#ifdef DEBUG
 		//LogMessage("DoTimedUpdates()");


### PR DESCRIPTION
Warning C4244 '=': conversion from 'time_t' to 'unsigned int', possible loss of data OPUNetGameServer \NetFixServer\GameServer.cpp 378