### PR TITLE
Switch header include guards

### DIFF
--- a/ErrorLog.h
+++ b/ErrorLog.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <iostream>
 
 #include "GameServer.h"

--- a/ErrorLog.h
+++ b/ErrorLog.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <iostream>
-
 #include "GameServer.h"
+#include <iostream>
 
 
 extern std::ostream &logFile;

--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -1,4 +1,3 @@
-// **DEBUG**
 //#define DEBUG
 #include "ErrorLog.h"
 #include "GameServer.h"

--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -1,13 +1,12 @@
 // **DEBUG**
 //#define DEBUG
 #include "ErrorLog.h"
+#include "GameServer.h"
 
 #ifndef WIN32
 	#define closesocket close
 	#define ioctlsocket ioctl
 #endif
-
-#include "GameServer.h"
 
 
 const unsigned int InitialGameListSize = 64;

--- a/GameServer.h
+++ b/GameServer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Packet.h"
+#include <time.h>
 
 #ifdef WIN32
 	#include <winsock2.h>
@@ -14,11 +16,6 @@
 	#define SOCKET_ERROR -1
 	#define INVALID_SOCKET -1
 #endif
-
-#include <time.h>
-
-#include "Packet.h"
-
 
 
 struct GameServerCounters

--- a/GameServer.h
+++ b/GameServer.h
@@ -1,6 +1,4 @@
-
-#ifndef GameServer_H_Seen
-#define GameServer_H_Seen
+#pragma once
 
 
 #ifdef WIN32
@@ -134,7 +132,3 @@ private:
 		int bWinsockInitialized;
 	#endif
 };
-
-
-
-#endif

--- a/Packet.h
+++ b/Packet.h
@@ -1,7 +1,4 @@
-
-#ifndef Packet_H_Seen
-#define Packet_H_Seen
-
+#pragma once
 
 
 #ifdef WIN32
@@ -213,7 +210,4 @@ public:
 // Restore old alignment setting
 #ifdef WIN32
 #pragma pack(pop)
-#endif
-
-
 #endif


### PR DESCRIPTION
I think ErrorLog.h not having an include guard was a mistake. Just tagged @DanRStevens to review in case it wasn't for some reason.