### PR TITLE
Const correct GUID compare

### DIFF
--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -14,7 +14,7 @@ const unsigned int UpdateTime = 60;			// Number of seconds before requesting upd
 const unsigned int RetryTime = 64;			// Number of seconds before requesting update retry
 const unsigned int GiveUpTime = 68;			// Number of seconds before clearing dead entries
 const unsigned int InitialReplyTime = 4;	// Number of seconds allowed for first update
-const GUID gameIdentifier = { 0x5A55CF11, 0xB841, 0x11CE, 0x92, 0x10, 0x00, 0xAA, 0x00, 0x6C, 0x49, 0x72 };
+const GUID gameIdentifier = { 0x5A55CF11, 0xB841, 0x11CE, {0x92, 0x10, 0x00, 0xAA, 0x00, 0x6C, 0x49, 0x72} };
 
 
 

--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -14,7 +14,7 @@ const unsigned int UpdateTime = 60;			// Number of seconds before requesting upd
 const unsigned int RetryTime = 64;			// Number of seconds before requesting update retry
 const unsigned int GiveUpTime = 68;			// Number of seconds before clearing dead entries
 const unsigned int InitialReplyTime = 4;	// Number of seconds allowed for first update
-GUID gameIdentifier = { 0x5A55CF11, 0xB841, 0x11CE, 0x92, 0x10, 0x00, 0xAA, 0x00, 0x6C, 0x49, 0x72 };
+const GUID gameIdentifier = { 0x5A55CF11, 0xB841, 0x11CE, 0x92, 0x10, 0x00, 0xAA, 0x00, 0x6C, 0x49, 0x72 };
 
 
 

--- a/Packet.h
+++ b/Packet.h
@@ -17,7 +17,7 @@
 		unsigned short Data3;
 		unsigned char Data4[8];
 
-		bool operator != (GUID &guid)
+		bool operator != (const GUID &guid) const
 		{
 			return (memcmp(this, &guid, sizeof(guid)) != 0);
 		}


### PR DESCRIPTION
Improves `const` correctness of GUID comparison.

Fixes Clang warning:
```
GameServer.cpp:17:59: warning: suggest braces around initialization of subobject [-Wmissing-braces]
const GUID gameIdentifier = { 0x5A55CF11, 0xB841, 0x11CE, 0x92, 0x10, 0x00, 0xAA, 0x00, 0x6C, 0x49, 0x72 };
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                          {                                             }
```
