### PR TITLE
Fix gcc sign mismatch

### DIFF
--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -555,7 +555,7 @@ unsigned int GameServer::GetNewRandValue()
 
 int GameServer::ReceiveFrom(Packet &packet, sockaddr_in &from)
 {
-	unsigned int numBytes;
+	int numBytes;
 	socklen_t addrLen = sizeof(from);
 
 	// Read any received packets

--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -555,11 +555,10 @@ unsigned int GameServer::GetNewRandValue()
 
 int GameServer::ReceiveFrom(Packet &packet, sockaddr_in &from)
 {
-	int numBytes;
 	socklen_t addrLen = sizeof(from);
 
 	// Read any received packets
-	numBytes = recvfrom(hostSocket, (char*)&packet, sizeof(packet), 0, (sockaddr*)&from, &addrLen);
+	int numBytes = recvfrom(hostSocket, (char*)&packet, sizeof(packet), 0, (sockaddr*)&from, &addrLen);
 
 	if (numBytes == SOCKET_ERROR)
 	{

--- a/GameServer.cpp
+++ b/GameServer.cpp
@@ -553,7 +553,7 @@ unsigned int GameServer::GetNewRandValue()
 }
 
 
-int GameServer::ReceiveFrom(Packet &packet, sockaddr_in &from)
+int GameServer::ReceiveFrom(Packet &packet, const sockaddr_in &from)
 {
 	socklen_t addrLen = sizeof(from);
 

--- a/GameServer.h
+++ b/GameServer.h
@@ -82,7 +82,7 @@ private:
 	int GetNewGameInfo();
 	void FreeGameInfo(std::size_t index);
 	unsigned int GetNewRandValue();
-	int ReceiveFrom(Packet &packet, sockaddr_in &from);
+	int ReceiveFrom(Packet &packet, const sockaddr_in &from);
 	void SendTo(Packet &packet, sockaddr_in &to);
 	void SendGameInfoRequest(sockaddr_in &to, unsigned int serverRandValue);
 	// Win32 specific functions

--- a/GameServer.h
+++ b/GameServer.h
@@ -83,6 +83,7 @@ private:
 	void FreeGameInfo(std::size_t index);
 	unsigned int GetNewRandValue();
 	int ReceiveFrom(Packet &packet, const sockaddr_in &from);
+	bool ReadSocketData(std::size_t& byteCountOut, SOCKET& socket, Packet& packetBuffer, const sockaddr_in& from);
 	void SendTo(Packet &packet, sockaddr_in &to);
 	void SendGameInfoRequest(sockaddr_in &to, unsigned int serverRandValue);
 	// Win32 specific functions


### PR DESCRIPTION
I made the change from unsigned to signed for numBytes based on resolving the GCC warning and because the example code in the MSDN documentation used a signed type. If we don't want to switch to a signed type, maybe we could stifle the warning for this portion of code...

https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom

This is from CircleCI's automated build in a different branch:
```
GameServer.cpp: In member function 'int GameServer::ReceiveFrom(Packet&, sockaddr_in&)':
GameServer.cpp:569:15: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
  if (numBytes == SOCKET_ERROR)
GameServer.cpp:574:16: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
   if (numBytes == SOCKET_ERROR)
g++ .build/obj/Packet.o .build/obj/main.o .build/obj/ErrorLog.o .build/obj/GameServer.o -lstdc++ -lm -o .build/bin/netfixserver
```