### PR TITLE
Fix Clang warnings about unaligned pointer

### DIFF
--- a/server/Packet.cpp
+++ b/server/Packet.cpp
@@ -10,7 +10,7 @@ int Packet::Checksum()
 
 	// Checksum the post-checksum fields
 	int dataChecksum = 0;
-	int* data = (&header.checksum) + 1;
+	auto* data = reinterpret_cast<int*>(reinterpret_cast<char*>(&header.checksum) + 4);
 
 	// Handle DWORD at a time
 	for (int i = header.sizeOfPayload / 4; i > 0; --i)


### PR DESCRIPTION
Closes #36

This code does necessarily need to handle a potentially unaligned pointer. Using `reinterpret_cast` with a byte aligned intermediate type silences this warning.

In the future, perhaps we can use a `union` to eliminate the need for the magic number `4` and the inner `reinterpret_cast`.
