### PR TITLE
Update TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ compiler:
   - gcc
   - clang
 script:
-  # Use -k to continue after errors, ensuring full build log with all errors
-  - make -k
+  - make --keep-going netFixServer
 notifications:
   email: false
 

--- a/makefile
+++ b/makefile
@@ -5,6 +5,9 @@
 TopLevelFolder := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
 
 
+.PHONY: all
+all: netFixServer
+
 SRCDIR := server
 BUILDDIR := .build
 BINDIR := $(BUILDDIR)/bin
@@ -24,7 +27,8 @@ SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(OBJDIR)/%.o,$(SRCS))
 FOLDERS := $(sort $(dir $(SRCS)))
 
-all: $(OUTPUT)
+.PHONY: netFixServer
+netFixServer: $(OUTPUT)
 
 $(OUTPUT): $(OBJS)
 	@mkdir -p ${@D}


### PR DESCRIPTION
Add explicit `netFixServer` target to `makefile`. If repositories are merged, we'll want to be explicit about only compiling the server on MacOS, as the client is Windows only.

Be explicit with the long form `--keep-going` flag, so there is no need to leave a comment.

----

MacOS and `makefile` only change.
