### PR TITLE
Enable warning zero-as-null-pointer-constant

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
 OUTPUT := $(BINDIR)/netfixserver
 
-CFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas
+CFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas -Wzero-as-null-pointer-constant
 LDFLAGS := -lstdc++ -lm
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td

--- a/server/GameServer.cpp
+++ b/server/GameServer.cpp
@@ -366,12 +366,12 @@ void GameServer::DoTimedUpdates()
 	#endif
 
 	// Get the current time
-	time_t currentTime = std::time(nullptr);
+	auto currentTime = std::time(nullptr);
 	// Check for timed out game entries
 	for (std::size_t i = gameSessions.size(); i-- > 0; )
 	{
 		// Get the current time difference
-		time_t timeDiff = currentTime - gameSessions[i].time;
+		auto timeDiff = currentTime - gameSessions[i].time;
 
 		// Check for no initial update within required time
 		if ((timeDiff >= InitialReplyTime) && ((gameSessions[i].flags & GameSessionReceived) == 0))

--- a/server/GameServer.cpp
+++ b/server/GameServer.cpp
@@ -101,7 +101,7 @@ void GameServer::WaitForEvent()
 	FD_SET(hostSocket, &readfds);
 	FD_SET(secondarySocket, &readfds);
 	// Wait for packets or timeout
-	select(1, &readfds, 0, 0, &timeOut);
+	select(1, &readfds, nullptr, nullptr, &timeOut);
 }
 
 

--- a/server/GameServer.cpp
+++ b/server/GameServer.cpp
@@ -263,7 +263,7 @@ void GameServer::ProcessGameSearchReply(Packet& packet, sockaddr_in& from)
 	gameSession.flags |= GameSessionReceived;
 	gameSession.flags &= ~GameSessionExpected & ~GameSessionUpdateRetrySent;
 	gameSession.createGameInfo = packet.tlMessage.searchReply.createGameInfo;
-	gameSession.time = time(nullptr);
+	gameSession.time = std::time(nullptr);
 }
 
 void GameServer::ProcessPoke(Packet& packet, sockaddr_in& from)
@@ -299,7 +299,7 @@ void GameServer::ProcessPoke(Packet& packet, sockaddr_in& from)
 		newGameSession.clientRandValue = packet.tlMessage.gameServerPoke.randValue;
 		newGameSession.serverRandValue = GetNewRandValue();
 		newGameSession.flags |= GameSessionExpected;
-		newGameSession.time = time(nullptr);
+		newGameSession.time = std::time(nullptr);
 
 		// Send a request for games
 		SendGameSessionRequest(from, newGameSession.serverRandValue);
@@ -366,7 +366,7 @@ void GameServer::DoTimedUpdates()
 	#endif
 
 	// Get the current time
-	time_t currentTime = time(nullptr);
+	time_t currentTime = std::time(nullptr);
 	// Check for timed out game entries
 	for (std::size_t i = gameSessions.size(); i-- > 0; )
 	{

--- a/server/GameServer.cpp
+++ b/server/GameServer.cpp
@@ -263,7 +263,7 @@ void GameServer::ProcessGameSearchReply(Packet& packet, sockaddr_in& from)
 	gameSession.flags |= GameSessionReceived;
 	gameSession.flags &= ~GameSessionExpected & ~GameSessionUpdateRetrySent;
 	gameSession.createGameInfo = packet.tlMessage.searchReply.createGameInfo;
-	gameSession.time = time(0);
+	gameSession.time = time(nullptr);
 }
 
 void GameServer::ProcessPoke(Packet& packet, sockaddr_in& from)
@@ -299,7 +299,7 @@ void GameServer::ProcessPoke(Packet& packet, sockaddr_in& from)
 		newGameSession.clientRandValue = packet.tlMessage.gameServerPoke.randValue;
 		newGameSession.serverRandValue = GetNewRandValue();
 		newGameSession.flags |= GameSessionExpected;
-		newGameSession.time = time(0);
+		newGameSession.time = time(nullptr);
 
 		// Send a request for games
 		SendGameSessionRequest(from, newGameSession.serverRandValue);
@@ -366,7 +366,7 @@ void GameServer::DoTimedUpdates()
 	#endif
 
 	// Get the current time
-	time_t currentTime = time(0);
+	time_t currentTime = time(nullptr);
 	// Check for timed out game entries
 	for (std::size_t i = gameSessions.size(); i-- > 0; )
 	{

--- a/server/GameServer.h
+++ b/server/GameServer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Packet.h"
-#include <time.h>
+#include <ctime>
 #include <cstring>
 #include <cstddef>
 #include <vector>

--- a/server/GameServer.h
+++ b/server/GameServer.h
@@ -63,7 +63,7 @@ private:
 	{
 		GUID sessionIdentifier;
 		sockaddr_in addr;
-		time_t time;
+		std::time_t time;
 		unsigned int clientRandValue;
 		unsigned int serverRandValue;
 		unsigned int flags = 0;


### PR DESCRIPTION
Enable warning flag `-Wzero-as-null-pointer-constant`, and fix associated warnings.

Reference: #29
This makes the warnings flags consistent across both the Server and Client projects.
