### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.build/
-*.userprefs
-.vs/
 Debug/
 Release/
+.vs/
+.build/
+*.userprefs
 *.user

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Release/
 .build/
 *.userprefs
 *.user
+NetFixServer.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.build
+.build/
 *.userprefs
-.vs
-Debug
-Release
+.vs/
+Debug/
+Release/
 *.user

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ BUILDDIR := .build
 BINDIR := $(BUILDDIR)/bin
 OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
-OUTPUT := $(BINDIR)/netfixserver
+OUTPUT := NetFixServer.exe
 
 CFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas
 LDFLAGS := -lstdc++ -lm


### PR DESCRIPTION
Make `.gitignore` more consistent with Client project.

Set Linux executable name and location to be more consistent with other projects.
