### PR TITLE
Remove check for logic error

### DIFF
--- a/server/GameServer.cpp
+++ b/server/GameServer.cpp
@@ -476,13 +476,6 @@ std::size_t GameServer::FindGameSessionServer(const sockaddr_in &from, unsigned 
 
 void GameServer::FreeGameSession(std::size_t index)
 {
-	// Make sure it's a valid index
-	if (index >= gameSessions.size())
-	{
-		LogMessage("Internal Error: Tried to free a non-existent GameSession record");
-		return;
-	}
-
 	gameSessions.erase(gameSessions.begin() + index);
 }
 


### PR DESCRIPTION
The check if for a logic error, rather than a runtime error. A logic error should actually bring the program crashing down, rather than silently logging an error and continuing. For the error to occur, there would need to be something fundamentally flawed about the calling code.

Reference: #32
